### PR TITLE
Document LLM-free name-behavior coherence rules

### DIFF
--- a/docs/adr/0001-modular-cli-pipeline.md
+++ b/docs/adr/0001-modular-cli-pipeline.md
@@ -1,0 +1,31 @@
+# ADR 0001: Modular CLI Analyzer Pipeline
+
+- **Status:** Accepted
+- **Date:** 2024-05-05
+- **Context:**
+  - The project must extract domain-specific language (DSL) concepts from full C++ codebases, detect incoherent usage, and run consistently on Linux and Windows.
+  - Portability, maintainability, and CI integration are primary quality goals; distributed orchestration is unnecessary at current scale.
+  - We need a structure that isolates clang-based parsing, DSL extraction heuristics, LLM prompting (if used), and reporting so each can evolve independently.
+
+- **Decision:**
+  - Build a **single-process CLI tool** organized as a **pipeline of modular stages**:
+    - **Source acquisition:** resolve repository root, compilation database, and include paths; output normalized source set.
+    - **Parsing and analysis:** run clang tooling to emit an AST index and semantic facts needed for DSL extraction.
+    - **DSL extraction:** transform AST facts into DSL terms (entities, actions, relationships) using deterministic rules and optional LLM prompts behind a narrow interface.
+    - **Coherence analysis:** identify conflicting or ambiguous DSL usages across the codebase.
+    - **Reporting:** emit human-readable Markdown plus machine-readable JSON for CI consumption; exit codes encode pass/fail for incoherence findings.
+  - Each stage exposes a clear input/output contract and can be swapped via dependency injection. Stages communicate via in-memory objects and may persist intermediate artifacts (e.g., AST cache) to disk for reuse.
+  - Provide extension points for heuristics and prompts as plug-in modules without changing pipeline wiring.
+
+- **Consequences:**
+  - **Positive:**
+    - High maintainability through isolated, testable stages; easier to extend heuristics or swap prompt strategies.
+    - Simple CI adoption via a single binary and deterministic exit codes; no distributed ops burden.
+    - Portability is handled within the CLI by configuring clang toolchains per OS; no network dependencies.
+  - **Negative/Trade-offs:**
+    - Limited horizontal scaling compared to distributed designs; large codebases rely on efficient single-process parallelism.
+    - Requires careful definition of stage contracts to avoid tight coupling.
+  - **Follow-up:**
+    - Define stage interfaces in code, including data contracts for AST facts and DSL term representations.
+    - Implement CLI commands/subcommands for analysis, cache management, and report generation.
+    - Specify deterministic name/behavior coherence rules (e.g., purity for `is*/has*`, mutation expectations for `set*`, and consistent semantics for repeated DSL terms like `path_length`) so offline analysis can flag misuses without LLMs.

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -25,28 +25,80 @@
 - **Observability:** Transparent reporting of detected DSL elements and conflicts for user review.
 
 ## 2. Architecture Constraints
-*To be detailed (e.g., tooling, standards, compliance, platform constraints).* 
+- Must run as a self-contained CLI on Linux and Windows, relying on clang/LLVM toolchain available on both platforms.
+- No external network dependencies during analysis (offline-friendly for CI).
+- Prefer deterministic, testable modules with clear contracts to support maintainability and extensibility.
+- Output must be consumable by CI (non-zero exit on incoherence findings, machine-readable JSON, Markdown for humans).
+- Repository uses pre-commit, clang-format, and clang-tidy; new code must conform.
 
 ## 3. System Scope and Context
 *To be detailed (business context and technical context diagrams, interfaces, and external dependencies).* 
 
 ## 4. Solution Strategy
-*To be detailed (overall architectural and technology decisions, use of clang AST and LLM integration strategies).* 
+- Adopt a **single-process CLI pipeline** (ADR 0001) with modular stages: source acquisition, clang-based parsing, DSL extraction, coherence analysis, and reporting.
+- Use clang tooling to build an AST index and semantic facts; avoid custom parsers.
+- Represent DSL terms (entities, actions, relationships) in a stable internal model that can be serialized to JSON.
+- Keep potential LLM usage behind an interface so deterministic heuristics remain the default and tests remain reproducible.
+- Provide extension points (plug-in modules) for extraction heuristics and coherence rules without altering pipeline wiring.
 
 ## 5. Building Block View
-*To be detailed (static structure, components, and responsibilities).* 
+
+### 5.1 High-Level Components
+- **CLI Frontend:** argument parsing, configuration loading, and command dispatch (e.g., `analyze`, `report`, `cache clean`).
+- **Source Acquisition:** resolves repository root, compilation database (`compile_commands.json`), include paths, and normalization of source files to analyze.
+- **Parsing & AST Indexer:** wraps clang tooling to produce a semantic index (symbols, types, call graph, comments); caches results for reuse.
+- **DSL Extraction Engine:** converts AST facts into DSL terms (domain entities, actions, relationships) using deterministic heuristics; optionally enriches via LLM strategies behind a small interface.
+- **Coherence Analyzer:** detects conflicting or ambiguous DSL usage across modules and files; maps findings to locations.
+- **Reporting Module:** renders Markdown and JSON outputs; manages exit codes based on findings severity; supports CI-friendly summaries.
+- **Plugin Interfaces:** contracts for extraction heuristics, coherence rules, and report renderers to allow future additions.
+
+#### 5.1.1 Name/Behavior Coherence Rules (LLM-free)
+- **Intent heuristics:** enforce naming conventions against observed behavior: `get*` must not mutate state; `set*` should assign or mutate; `is*/has*` must return boolean and remain side-effect free; resource verbs (`open/close/init/teardown`) must align with lifecycle events in the call graph.
+- **Consistency across occurrences:** symbols sharing a DSL term (e.g., `path_length`) must express comparable semantics. The Coherence Analyzer compares AST facts (call targets, operations, side effects) across implementations to flag divergence—such as one `path_length` derived from vector norms vs. another obtained via `estimate_overall_path_length(path)`—without any LLM involvement.
+- **Fact sources:** relies on the AST index for symbol definitions, control-flow summaries (mutations, returns, exceptions), call graph edges, and basic type info to run the rules deterministically.
+
+### 5.2 Data Structures
+- **AST Fact Model:** normalized representation of declarations, definitions, symbol references, and comments.
+- **DSL Term Model:** typed objects for entities, actions, relationships, and provenance metadata (file, line, symbol origin).
+- **Findings Model:** coherence issues with severity, description, and source locations.
+
+### 5.3 Module Dependencies
+- CLI Frontend depends on Source Acquisition and Reporting.
+- Source Acquisition feeds Parsing & AST Indexer.
+- Parsing & AST Indexer feeds DSL Extraction Engine.
+- DSL Extraction Engine feeds Coherence Analyzer and Reporting.
+- Reporting consumes DSL Term Model and Findings Model.
 
 ## 6. Runtime View
-*To be detailed (key scenarios and their runtime interactions).* 
+
+### Scenario: Analyze Repository for DSL Coherence
+1. **CLI Frontend** parses arguments (e.g., `dsl-extract analyze --format markdown,json --out reports/`).
+2. **Source Acquisition** loads configuration, resolves repository root, and reads `compile_commands.json`; outputs normalized file list and compilation settings.
+3. **Parsing & AST Indexer** runs clang tooling to build the AST fact model; caches intermediate artifacts if enabled.
+4. **DSL Extraction Engine** transforms AST facts into DSL terms using configured heuristics or plug-ins.
+5. **Coherence Analyzer** evaluates DSL terms to find conflicts or ambiguities; produces findings.
+6. **Reporting Module** renders Markdown and JSON; sets exit code (0 if no issues, non-zero otherwise) for CI.
+7. Optional: **Cache Manager** can persist AST facts to accelerate subsequent runs.
 
 ## 7. Deployment View
-*To be detailed (environments, nodes, and deployment topologies for Linux and Windows).* 
+- **Packaging:** distribute as a single CLI (static or self-contained) with dependencies on clang/LLVM runtimes.
+- **Environments:**
+  - **Developer machines:** Linux and Windows with local clang toolchain; optional cache directory per repo.
+  - **CI agents:** run CLI in build pipelines; artifacts (JSON/Markdown) stored as pipeline outputs.
+- **Configuration:** paths to toolchain, include directories, and compilation database provided via CLI args or config file.
+- **Data:** optional on-disk cache for AST facts stored under project `.dsl-cache/` to speed reruns; cleaned via CLI command.
 
 ## 8. Crosscutting Concepts
-*To be detailed (logging, configuration, security, error handling, LLM usage).* 
+- **Configuration:** YAML/TOML config plus CLI overrides; validation at startup; defaults favor deterministic analysis.
+- **Logging & Observability:** structured logging with verbosity flags; timing metrics per stage; summary of file counts and findings.
+- **Error Handling:** fail fast with contextual errors; non-zero exits on fatal parsing errors or incoherence findings.
+- **Caching:** optional AST cache keyed by toolchain/version and source hash to avoid full reparse.
+- **Extensibility:** plug-in registry for extraction heuristics, coherence rules, and report renderers; interfaces versioned.
+- **LLM Usage:** optional strategy behind a small interface; must allow deterministic fallback; prompts and outputs logged for audit when enabled.
+- **Testing:** unit tests per stage with mock contracts; integration tests run full pipeline on sample C++ fixtures.
 
 ## 9. Architecture Decisions
-*To be detailed (ADR references and status).* 
+- **ADR 0001:** Adopt modular single-process CLI pipeline with staged analysis and plug-in extension points (`docs/adr/0001-modular-cli-pipeline.md`).
 
 ## 10. Quality Requirements
 *To be detailed (quality tree and scenarios aligned with architecture characteristics).* 


### PR DESCRIPTION
## Summary
- document deterministic name/behavior coherence checks in the arc42 building block view
- add ADR follow-up to define offline heuristics for name-behavior alignment such as consistent `path_length` semantics

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c0570808832a80fc873b67eb21ae)