### PR TITLE
Implement AST indexer contract and tests

### DIFF
--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -60,7 +60,7 @@
 ### 5.2 Data Structures
 - **AnalysisConfig:** provides `root_path` and preferred output `formats` for analysis tooling.
 - **SourceAcquisitionResult:** normalized `files` list (deduplicated, sorted) and a normalized `project_root` shared across pipeline stages.
-- **AST Fact Model:** normalized representation of declarations, definitions, symbol references, and comments.
+- **AST Fact Model:** normalized representation of declarations, definitions, symbol references, and comments. Each fact captures the `name`, `kind` (e.g., `class`, `struct`, `function`), and a `SourceLocation` with canonical `file_path` and `line` number to keep extraction deterministic.
 - **DSL Term Model:** typed objects for entities, actions, relationships, and provenance metadata (file, line, symbol origin).
 - **Findings Model:** coherence issues with severity, description, and source locations.
 
@@ -74,6 +74,16 @@
 - **Outputs:**
   - Deterministic list of absolute source/header paths ready for AST indexing.
   - Normalized root path shared across pipeline stages.
+
+### 5.5 AST Indexer Contract
+- **Inputs:**
+  - `SourceAcquisitionResult` containing the canonicalized project root and list of source files.
+- **Processing rules:**
+  - Parse each provided source file, deriving semantic facts for top-level constructs (classes/structs) and function definitions using deterministic heuristics; no network access is required.
+  - Canonicalize file paths and preserve line numbers for every fact so downstream stages can report evidence locations.
+  - Reject empty source lists early with a clear error to avoid silent no-op analyses.
+- **Outputs:**
+  - `AstIndex` containing the project root and a stable, line-ordered collection of `AstFact` entries ready for DSL extraction.
 
 ### 5.3 Module Dependencies
 - CLI Frontend depends on Source Acquisition and Reporting.

--- a/include/dsl/models.h
+++ b/include/dsl/models.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -15,13 +16,20 @@ struct SourceAcquisitionResult {
   std::string project_root;
 };
 
+struct SourceLocation {
+  std::string file_path;
+  std::size_t line = 0;
+};
+
 struct AstFact {
   std::string name;
   std::string kind;
+  SourceLocation location;
 };
 
 struct AstIndex {
   std::vector<AstFact> facts;
+  std::string project_root;
 };
 
 struct DslTerm {


### PR DESCRIPTION
## Summary
- extend AST models with source locations and project root context
- implement the SimpleAstIndexer to parse source files into ordered facts and enrich DSL extraction definitions
- document the AST indexer contract and expand unit tests for indexing and pipeline behavior

## Testing
- ctest --test-dir build --output-on-failure -j

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69375c3e5724832a83f71ed21df4996f)