### PR TITLE
Refactor ternary operators for clarity

### DIFF
--- a/src/default_components.cpp
+++ b/src/default_components.cpp
@@ -20,7 +20,11 @@ DslExtractionResult HeuristicDslExtractor::Extract(const AstIndex &index) {
   for (const auto &fact : index.facts) {
     DslTerm term;
     term.name = fact.name;
-    term.kind = fact.kind == "type" ? "Entity" : "Action";
+    if (fact.kind == "type") {
+      term.kind = "Entity";
+    } else {
+      term.kind = "Action";
+    }
     term.definition = "Derived from " + fact.name;
     term.evidence.push_back(fact.name + ":1-5");
     term.aliases.push_back(fact.name + "Alias");

--- a/src/markdown_reporter.cpp
+++ b/src/markdown_reporter.cpp
@@ -71,9 +71,11 @@ std::string BuildAnalysisHeaderMarkdown(const AnalysisConfig &config,
   section << "| --- | --- |\n";
   section << "| Generated On | " << timestamp << " |\n";
   section << "| Source | " << config.root_path << " |\n";
-  section << "| Scope Notes | "
-          << (config.scope_notes.empty() ? "None" : config.scope_notes)
-          << " |\n\n";
+  std::string scope_notes = "None";
+  if (!config.scope_notes.empty()) {
+    scope_notes = config.scope_notes;
+  }
+  section << "| Scope Notes | " << scope_notes << " |\n\n";
   return section.str();
 }
 
@@ -109,11 +111,16 @@ std::string BuildRelationshipsMarkdown(const DslExtractionResult &extraction) {
   }
 
   for (const auto &relationship : extraction.relationships) {
+    std::string relationship_notes = "-";
+    if (!relationship.notes.empty()) {
+      relationship_notes = relationship.notes;
+    }
+
     section << "| " << relationship.subject << " | " << relationship.verb
             << " | " << relationship.object << " | "
             << JoinWithBreaks(relationship.evidence) << " | "
-            << (relationship.notes.empty() ? "-" : relationship.notes) << " | "
-            << relationship.usage_count << " |\n";
+            << relationship_notes << " | " << relationship.usage_count
+            << " |\n";
   }
   section << "\n";
   return section.str();
@@ -150,13 +157,20 @@ std::string BuildIncoherenceMarkdown(const CoherenceResult &coherence) {
   }
 
   for (const auto &finding : coherence.findings) {
-    const auto conflict =
-        finding.conflict.empty() ? finding.description : finding.conflict;
-    const auto suggested_canonical = finding.suggested_canonical_form.empty()
-                                         ? "-"
-                                         : finding.suggested_canonical_form;
-    const auto details =
-        finding.description.empty() ? finding.conflict : finding.description;
+    std::string conflict = finding.description;
+    if (!finding.conflict.empty()) {
+      conflict = finding.conflict;
+    }
+
+    std::string suggested_canonical = "-";
+    if (!finding.suggested_canonical_form.empty()) {
+      suggested_canonical = finding.suggested_canonical_form;
+    }
+
+    std::string details = finding.conflict;
+    if (!finding.description.empty()) {
+      details = finding.description;
+    }
 
     section << "| " << finding.term << " | " << conflict << " | "
             << JoinWithBreaks(finding.examples) << " | " << suggested_canonical
@@ -187,10 +201,11 @@ std::string BuildAnalysisHeaderJson(const AnalysisConfig &config,
   json << "\"analysis_header\": {";
   json << "\"generated_on\": \"" << EscapeJsonString(timestamp) << "\",";
   json << "\"source\": \"" << EscapeJsonString(config.root_path) << "\",";
-  json << "\"scope_notes\": \""
-       << EscapeJsonString(config.scope_notes.empty() ? "None"
-                                                      : config.scope_notes)
-       << "\"}";
+  std::string scope_notes = "None";
+  if (!config.scope_notes.empty()) {
+    scope_notes = config.scope_notes;
+  }
+  json << "\"scope_notes\": \"" << EscapeJsonString(scope_notes) << "\"}";
   return json.str();
 }
 


### PR DESCRIPTION
## Summary
- replace ternary operators with explicit conditional branches in DSL extraction and reporting
- clarify handling of scope notes, relationship notes, and coherence details without terse expressions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938bb25ccbc832a96443bce06efdde5)