### PR TITLE
Add ignored path support to DSL analyzer

### DIFF
--- a/include/dsl/dsl_analyzer.h
+++ b/include/dsl/dsl_analyzer.h
@@ -21,6 +21,7 @@ struct AnalyzeOptions {
   std::optional<std::string> reporter;
   std::vector<std::string> formats;
   std::vector<std::string> ignored_namespaces;
+  std::vector<std::filesystem::path> ignored_paths;
   std::optional<dsl::LogLevel> log_level;
   std::optional<bool> enable_ast_cache;
   std::optional<bool> clean_cache;

--- a/include/dsl/models.h
+++ b/include/dsl/models.h
@@ -2,6 +2,7 @@
 
 #include <dsl/logging.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -14,6 +15,7 @@ struct AnalysisConfig {
   std::string scope_notes;
   LoggingConfig logging;
   std::vector<std::string> ignored_namespaces{"std", "testing", "gtest"};
+  std::vector<std::string> ignored_paths;
   struct CacheConfig {
     bool enable_ast_cache = false;
     bool clean = false;

--- a/src/cmake_source_acquirer.cpp
+++ b/src/cmake_source_acquirer.cpp
@@ -5,6 +5,7 @@
 #include <iterator>
 #include <set>
 #include <stdexcept>
+#include <vector>
 
 namespace dsl {
 
@@ -48,6 +49,12 @@ bool IsCollectableFile(const std::filesystem::directory_entry &entry,
   return IsSourceExtension(path) && !IsWithin(path, build_dir);
 }
 
+bool IsIgnoredPath(const std::filesystem::path &path,
+                   const std::vector<std::filesystem::path> &ignored_paths) {
+  return std::any_of(ignored_paths.begin(), ignored_paths.end(),
+                     [&](const auto &ignored) { return IsWithin(path, ignored); });
+}
+
 std::filesystem::path ResolveRootPath(const AnalysisConfig &config) {
   if (config.root_path.empty()) {
     throw std::invalid_argument("AnalysisConfig.root_path must not be empty.");
@@ -75,12 +82,21 @@ void RequireCMakeProject(const std::filesystem::path &root) {
 
 std::vector<std::string>
 CollectSourceFiles(const std::filesystem::path &root,
-                   const std::filesystem::path &build_dir) {
+                   const std::filesystem::path &build_dir,
+                   const std::vector<std::filesystem::path> &ignored_paths) {
   std::vector<std::string> files;
 
   for (std::filesystem::recursive_directory_iterator it(root), end; it != end;
        ++it) {
     const auto &entry = *it;
+    const auto canonical_path =
+        std::filesystem::weakly_canonical(entry.path());
+    if (IsIgnoredPath(canonical_path, ignored_paths)) {
+      if (entry.is_directory()) {
+        it.disable_recursion_pending();
+      }
+      continue;
+    }
     if (IsBuildDirectory(entry, build_dir)) {
       it.disable_recursion_pending();
       continue;
@@ -90,7 +106,7 @@ CollectSourceFiles(const std::filesystem::path &root,
       continue;
     }
 
-    files.push_back(std::filesystem::weakly_canonical(entry.path()).string());
+    files.push_back(canonical_path.string());
   }
 
   std::sort(files.begin(), files.end());
@@ -118,7 +134,13 @@ CMakeSourceAcquirer::Acquire(const AnalysisConfig &config) {
   }
   build_dir = std::filesystem::weakly_canonical(build_dir);
 
-  auto files = CollectSourceFiles(root, build_dir);
+  std::vector<std::filesystem::path> ignored_paths;
+  ignored_paths.reserve(config.ignored_paths.size());
+  for (const auto &ignored : config.ignored_paths) {
+    ignored_paths.emplace_back(ignored);
+  }
+
+  auto files = CollectSourceFiles(root, build_dir, ignored_paths);
   if (files.empty()) {
     throw std::runtime_error("No source files found under root: " +
                              root.string());

--- a/src/cmake_source_acquirer.cpp
+++ b/src/cmake_source_acquirer.cpp
@@ -51,8 +51,9 @@ bool IsCollectableFile(const std::filesystem::directory_entry &entry,
 
 bool IsIgnoredPath(const std::filesystem::path &path,
                    const std::vector<std::filesystem::path> &ignored_paths) {
-  return std::any_of(ignored_paths.begin(), ignored_paths.end(),
-                     [&](const auto &ignored) { return IsWithin(path, ignored); });
+  return std::any_of(
+      ignored_paths.begin(), ignored_paths.end(),
+      [&](const auto &ignored) { return IsWithin(path, ignored); });
 }
 
 std::filesystem::path ResolveRootPath(const AnalysisConfig &config) {
@@ -89,8 +90,7 @@ CollectSourceFiles(const std::filesystem::path &root,
   for (std::filesystem::recursive_directory_iterator it(root), end; it != end;
        ++it) {
     const auto &entry = *it;
-    const auto canonical_path =
-        std::filesystem::weakly_canonical(entry.path());
+    const auto canonical_path = std::filesystem::weakly_canonical(entry.path());
     if (IsIgnoredPath(canonical_path, ignored_paths)) {
       if (entry.is_directory()) {
         it.disable_recursion_pending();

--- a/src/dsl_analyzer.cpp
+++ b/src/dsl_analyzer.cpp
@@ -191,8 +191,8 @@ void AppendIgnoredPaths(const std::string &raw_paths,
 
     const std::filesystem::path path(
         std::filesystem::path(path_value).generic_string());
-    const auto matches = std::find_if(
-        target.begin(), target.end(), [&](const auto &existing) {
+    const auto matches =
+        std::find_if(target.begin(), target.end(), [&](const auto &existing) {
           return existing.generic_string() == path.generic_string();
         });
     if (matches == target.end()) {
@@ -209,10 +209,8 @@ void AppendRawPathStrings(const std::string &raw_paths,
       continue;
     }
 
-    const auto normalized =
-        std::filesystem::path(path_value).generic_string();
-    if (std::find(target.begin(), target.end(), normalized) ==
-        target.end()) {
+    const auto normalized = std::filesystem::path(path_value).generic_string();
+    if (std::find(target.begin(), target.end(), normalized) == target.end()) {
       target.push_back(normalized);
     }
   }
@@ -285,7 +283,7 @@ void HandleIgnoredPathsOption(const std::vector<std::string> &arguments,
   const auto &argument = arguments[index];
   if (argument == "--ignored-paths") {
     AppendIgnoredPaths(RequireValue(arguments, index, "--ignored-paths"),
-                      options.ignored_paths);
+                       options.ignored_paths);
   }
 }
 

--- a/tests/cmake_source_acquirer_test.cpp
+++ b/tests/cmake_source_acquirer_test.cpp
@@ -56,16 +56,15 @@ TEST_F(CMakeSourceAcquirerTest, SkipsFilesUnderIgnoredPaths) {
   project_.AddFile("source/generated.cpp", "void generated();");
 
   auto config = MakeConfig();
-  config.ignored_paths =
-      {std::filesystem::weakly_canonical(project_.root() / "source")
-           .generic_string()};
+  config.ignored_paths = {
+      std::filesystem::weakly_canonical(project_.root() / "source")
+          .generic_string()};
 
   const auto result = acquirer_.Acquire(config);
 
   EXPECT_THAT(result.files,
-              ::testing::ElementsAre(std::filesystem::weakly_canonical(
-                                          kept_source)
-                                          .string()));
+              ::testing::ElementsAre(
+                  std::filesystem::weakly_canonical(kept_source).string()));
 }
 
 } // namespace

--- a/tests/cmake_source_acquirer_test.cpp
+++ b/tests/cmake_source_acquirer_test.cpp
@@ -49,5 +49,24 @@ TEST_F(CMakeSourceAcquirerTest, ThrowsWhenProjectIsNotCMakeBased) {
   EXPECT_THROW(acquirer_.Acquire(MakeConfig()), std::runtime_error);
 }
 
+TEST_F(CMakeSourceAcquirerTest, SkipsFilesUnderIgnoredPaths) {
+  project_.AddFile("CMakeLists.txt", "cmake_minimum_required(VERSION 3.20)\n");
+  const auto kept_source =
+      project_.AddFile("src/main.cpp", "int main() {return 0;}");
+  project_.AddFile("source/generated.cpp", "void generated();");
+
+  auto config = MakeConfig();
+  config.ignored_paths =
+      {std::filesystem::weakly_canonical(project_.root() / "source")
+           .generic_string()};
+
+  const auto result = acquirer_.Acquire(config);
+
+  EXPECT_THAT(result.files,
+              ::testing::ElementsAre(std::filesystem::weakly_canonical(
+                                          kept_source)
+                                          .string()));
+}
+
 } // namespace
 } // namespace dsl

--- a/tests/dsl_analyzer_test.cpp
+++ b/tests/dsl_analyzer_test.cpp
@@ -10,12 +10,12 @@ namespace {
 
 TEST(ParseAnalyzeArgumentsTest, ParsesFlagsAndValues) {
   const std::vector<std::string> args = {
-      "--root",        "/project/root",   "--build",     "build-dir",
-      "--format",      "markdown,json",   "--out",       "out-dir",
-      "--scope-notes", "notes",           "--config",    "config.yml",
-      "--log-level",   "debug",           "--cache-ast", "--clean-cache",
-      "--cache-dir",   "cache",           "--extractor", "custom-extractor",
-      "--analyzer",    "custom-analyzer", "--reporter",  "custom-reporter",
+      "--root",          "/project/root",   "--build",     "build-dir",
+      "--format",        "markdown,json",   "--out",       "out-dir",
+      "--scope-notes",   "notes",           "--config",    "config.yml",
+      "--log-level",     "debug",           "--cache-ast", "--clean-cache",
+      "--cache-dir",     "cache",           "--extractor", "custom-extractor",
+      "--analyzer",      "custom-analyzer", "--reporter",  "custom-reporter",
       "--ignored-paths", "source,tmp"};
 
   const auto options = ParseAnalyzeArguments(args);

--- a/tests/dsl_analyzer_test.cpp
+++ b/tests/dsl_analyzer_test.cpp
@@ -15,7 +15,8 @@ TEST(ParseAnalyzeArgumentsTest, ParsesFlagsAndValues) {
       "--scope-notes", "notes",           "--config",    "config.yml",
       "--log-level",   "debug",           "--cache-ast", "--clean-cache",
       "--cache-dir",   "cache",           "--extractor", "custom-extractor",
-      "--analyzer",    "custom-analyzer", "--reporter",  "custom-reporter"};
+      "--analyzer",    "custom-analyzer", "--reporter",  "custom-reporter",
+      "--ignored-paths", "source,tmp"};
 
   const auto options = ParseAnalyzeArguments(args);
 
@@ -38,6 +39,9 @@ TEST(ParseAnalyzeArgumentsTest, ParsesFlagsAndValues) {
   EXPECT_EQ(options.extractor, std::optional<std::string>("custom-extractor"));
   EXPECT_EQ(options.analyzer, std::optional<std::string>("custom-analyzer"));
   EXPECT_EQ(options.reporter, std::optional<std::string>("custom-reporter"));
+  ASSERT_EQ(options.ignored_paths.size(), 2u);
+  EXPECT_EQ(options.ignored_paths[0].generic_string(), "source");
+  EXPECT_EQ(options.ignored_paths[1].generic_string(), "tmp");
 }
 
 TEST(ParseReportArgumentsTest, ParsesFlagsAndFormats) {
@@ -70,6 +74,9 @@ TEST(ParseConfigFileTest, ParsesYamlNestedValuesAndFormatsList) {
   config_stream << "extractor: yaml-extractor\n";
   config_stream << "analyzer: yaml-analyzer\n";
   config_stream << "reporter: yaml-reporter\n";
+  config_stream << "ignored_paths:\n";
+  config_stream << "  - source\n";
+  config_stream << "  - generated\n";
   config_stream.close();
 
   const auto options = ParseConfigFile(temp_config);
@@ -91,6 +98,9 @@ TEST(ParseConfigFileTest, ParsesYamlNestedValuesAndFormatsList) {
   EXPECT_EQ(options.extractor, std::optional<std::string>("yaml-extractor"));
   EXPECT_EQ(options.analyzer, std::optional<std::string>("yaml-analyzer"));
   EXPECT_EQ(options.reporter, std::optional<std::string>("yaml-reporter"));
+  ASSERT_EQ(options.ignored_paths.size(), 2u);
+  EXPECT_EQ(options.ignored_paths[0].generic_string(), "source");
+  EXPECT_EQ(options.ignored_paths[1].generic_string(), "generated");
   std::filesystem::remove(temp_config);
 }
 


### PR DESCRIPTION
## Summary
- add CLI and config support for specifying paths to ignore during DSL analysis
- normalize ignored paths and skip sources under them when collecting files
- extend analyzer and source acquirer tests to cover the new option

## Testing
- cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug *(fails: missing libclang dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694742417c80832a88da54dc2ffe9d65)