### PR TITLE
Add support for ignoring source directories

### DIFF
--- a/include/dsl/dsl_analyzer.h
+++ b/include/dsl/dsl_analyzer.h
@@ -21,6 +21,7 @@ struct AnalyzeOptions {
   std::optional<std::string> reporter;
   std::vector<std::string> formats;
   std::vector<std::string> ignored_namespaces;
+  std::vector<std::string> ignored_source_directories;
   std::optional<dsl::LogLevel> log_level;
   std::optional<bool> enable_ast_cache;
   std::optional<bool> clean_cache;

--- a/include/dsl/models.h
+++ b/include/dsl/models.h
@@ -2,6 +2,7 @@
 
 #include <dsl/logging.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -14,6 +15,7 @@ struct AnalysisConfig {
   std::string scope_notes;
   LoggingConfig logging;
   std::vector<std::string> ignored_namespaces{"std", "testing", "gtest"};
+  std::vector<std::filesystem::path> ignored_source_directories;
   struct CacheConfig {
     bool enable_ast_cache = false;
     bool clean = false;


### PR DESCRIPTION
## Summary
- add CLI/config support for specifying source folders to ignore during analysis
- propagate ignored source directories into analysis config and collection pipeline
- extend analyzer and source acquirer tests to cover the new behavior

## Testing
- pre-commit run --all-files
- ctest --test-dir build --output-on-failure -j


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949942b6cd0832ab2e766018afd0a60)