### PR TITLE
Enhance AST facts with scope and comments

### DIFF
--- a/include/dsl/models.h
+++ b/include/dsl/models.h
@@ -39,6 +39,8 @@ struct AstFact {
   std::string descriptor;
   std::string target;
   std::string range;
+  std::string doc_comment;
+  std::string scope_path;
   bool subject_in_project = false;
   enum class TargetScope {
     kUnknown,

--- a/src/heuristic_dsl_extractor.cpp
+++ b/src/heuristic_dsl_extractor.cpp
@@ -132,13 +132,20 @@ private:
 };
 
 std::string EvidenceLocation(const dsl::AstFact &fact) {
+  std::string location;
   if (fact.source_location.empty()) {
-    return fact.range;
+    location = fact.range;
   }
-  if (fact.range.empty()) {
-    return fact.source_location;
+  if (location.empty()) {
+    location = fact.source_location;
   }
-  return fact.source_location + "@" + fact.range;
+  if (!fact.scope_path.empty()) {
+    if (location.empty()) {
+      return fact.scope_path;
+    }
+    return fact.scope_path + "@" + location;
+  }
+  return location;
 }
 
 std::string DeriveTermKind(const std::string &base_kind) {
@@ -331,6 +338,8 @@ void TrackExternalDependency(const dsl::AstFact &fact, TermMap &externals) {
   dependency.kind = "External";
   AppendDefinitionPart(fact.descriptor, dependency);
   AppendDefinitionPart(fact.signature, dependency);
+  AppendDefinitionPart(fact.doc_comment, dependency);
+  AppendDefinitionPart(fact.scope_path, dependency);
   AddEvidence(EvidenceLocation(fact), dependency.evidence);
   ++dependency.usage_count;
 }
@@ -352,8 +361,10 @@ void UpdateTermFromFact(const dsl::AstFact &fact, TermMap &terms,
   auto &term = terms[canonical_name];
   term.name = canonical_name;
   EnsureKindInitialized(parsed, term);
+  AppendDefinitionPart(fact.doc_comment, term);
   AppendDefinitionPart(parsed.descriptor.value_or(""), term);
   AppendDefinitionPart(fact.signature, term);
+  AppendDefinitionPart(fact.scope_path, term);
   AddEvidence(EvidenceLocation(fact), term.evidence);
   ++term.usage_count;
   AppendAlias(canonical_name, fact.name, aliases, term);

--- a/src/heuristic_dsl_extractor.cpp
+++ b/src/heuristic_dsl_extractor.cpp
@@ -132,12 +132,13 @@ private:
 };
 
 std::string EvidenceLocation(const dsl::AstFact &fact) {
-  std::string location;
-  if (fact.source_location.empty()) {
-    location = fact.range;
-  }
-  if (location.empty()) {
-    location = fact.source_location;
+  std::string location = fact.source_location;
+  if (!fact.range.empty() && fact.range != fact.source_location) {
+    if (location.empty()) {
+      location = fact.range;
+    } else {
+      location.append("@").append(fact.range);
+    }
   }
   if (!fact.scope_path.empty()) {
     if (location.empty()) {

--- a/tests/compile_commands_ast_indexer_test.cpp
+++ b/tests/compile_commands_ast_indexer_test.cpp
@@ -41,11 +41,29 @@ TEST(CompileCommandsAstIndexerTest, ExtractsFactsFromTranslationUnits) {
   test::TemporaryProject project;
   const auto source_path = project.AddFile(
       "src/example.cpp",
-      "struct Widget { int value; };\nint Add(int a, int b) "
-      "{ return a + b; }\ndouble threshold = 3.14;\nint Use(const "
-      "Widget &widget) { return Add(widget.value, "
-      "static_cast<int>(threshold)); "
-      "}\n");
+      R"(namespace sample {
+/// Widget entity
+struct Widget {
+  /// Holds a widget value
+  int value;
+};
+
+class Calculator {
+public:
+  /// Adds numbers together
+  int Add(int a, int b) { return a + b; }
+};
+
+/// Threshold for widget calculations
+double threshold = 3.14;
+
+/// Uses a widget value inside a nested scope
+int Use(const Widget &widget) {
+  Calculator calculator;
+  return calculator.Add(widget.value, static_cast<int>(threshold));
+}
+}  // namespace sample
+)");
   const auto build_dir = project.root() / "build";
   std::filesystem::create_directories(build_dir);
   const auto generated_path =
@@ -82,21 +100,29 @@ TEST(CompileCommandsAstIndexerTest, ExtractsFactsFromTranslationUnits) {
   EXPECT_THAT(
       index.facts,
       Contains(
-          AllOf(Field(&AstFact::name, "Widget"), Field(&AstFact::kind, "type"),
+          AllOf(Field(&AstFact::name, "sample::Widget"),
+                Field(&AstFact::kind, "type"),
                 Field(&AstFact::signature, HasSubstr("Widget")),
-                Field(&AstFact::source_location, HasSubstr("example.cpp:1")))));
+                Field(&AstFact::doc_comment, HasSubstr("Widget entity")),
+                Field(&AstFact::scope_path, "sample"),
+                Field(&AstFact::source_location, HasSubstr("example.cpp:3")))));
   EXPECT_THAT(
       index.facts,
       Contains(
-          AllOf(Field(&AstFact::name, "Add"), Field(&AstFact::kind, "function"),
+          AllOf(Field(&AstFact::name, "sample::Calculator::Add"),
+                Field(&AstFact::kind, "function"),
                 Field(&AstFact::signature, HasSubstr("int Add(int")),
-                Field(&AstFact::source_location, HasSubstr("example.cpp:2")))));
+                Field(&AstFact::doc_comment, HasSubstr("Adds numbers")),
+                Field(&AstFact::scope_path, "sample::Calculator"),
+                Field(&AstFact::source_location, HasSubstr("example.cpp:11")))));
   EXPECT_THAT(
       index.facts,
       Contains(AllOf(
-          Field(&AstFact::name, "threshold"), Field(&AstFact::kind, "variable"),
+          Field(&AstFact::name, "sample::threshold"),
+          Field(&AstFact::kind, "variable"),
           Field(&AstFact::descriptor, HasSubstr("double")),
-          Field(&AstFact::source_location, HasSubstr("example.cpp:3")))));
+          Field(&AstFact::scope_path, "sample"),
+          Field(&AstFact::source_location, HasSubstr("example.cpp:15")))));
 }
 
 TEST(CompileCommandsAstIndexerTest,

--- a/tests/compile_commands_ast_indexer_test.cpp
+++ b/tests/compile_commands_ast_indexer_test.cpp
@@ -39,9 +39,8 @@ void ReplaceAll(std::string &text, const std::string &placeholder,
 
 TEST(CompileCommandsAstIndexerTest, ExtractsFactsFromTranslationUnits) {
   test::TemporaryProject project;
-  const auto source_path = project.AddFile(
-      "src/example.cpp",
-      R"(namespace sample {
+  const auto source_path = project.AddFile("src/example.cpp",
+                                           R"(namespace sample {
 /// Widget entity
 struct Widget {
   /// Holds a widget value
@@ -108,21 +107,20 @@ int Use(const Widget &widget) {
                 Field(&AstFact::source_location, HasSubstr("example.cpp:3")))));
   EXPECT_THAT(
       index.facts,
-      Contains(
-          AllOf(Field(&AstFact::name, "sample::Calculator::Add"),
-                Field(&AstFact::kind, "function"),
-                Field(&AstFact::signature, HasSubstr("int Add(int")),
-                Field(&AstFact::doc_comment, HasSubstr("Adds numbers")),
-                Field(&AstFact::scope_path, "sample::Calculator"),
-                Field(&AstFact::source_location, HasSubstr("example.cpp:11")))));
-  EXPECT_THAT(
-      index.facts,
       Contains(AllOf(
-          Field(&AstFact::name, "sample::threshold"),
-          Field(&AstFact::kind, "variable"),
-          Field(&AstFact::descriptor, HasSubstr("double")),
-          Field(&AstFact::scope_path, "sample"),
-          Field(&AstFact::source_location, HasSubstr("example.cpp:15")))));
+          Field(&AstFact::name, "sample::Calculator::Add"),
+          Field(&AstFact::kind, "function"),
+          Field(&AstFact::signature, HasSubstr("int Add(int")),
+          Field(&AstFact::doc_comment, HasSubstr("Adds numbers")),
+          Field(&AstFact::scope_path, "sample::Calculator"),
+          Field(&AstFact::source_location, HasSubstr("example.cpp:11")))));
+  EXPECT_THAT(index.facts,
+              Contains(AllOf(Field(&AstFact::name, "sample::threshold"),
+                             Field(&AstFact::kind, "variable"),
+                             Field(&AstFact::descriptor, HasSubstr("double")),
+                             Field(&AstFact::scope_path, "sample"),
+                             Field(&AstFact::source_location,
+                                   HasSubstr("example.cpp:15")))));
 }
 
 TEST(CompileCommandsAstIndexerTest,

--- a/tests/heuristic_dsl_extractor_test.cpp
+++ b/tests/heuristic_dsl_extractor_test.cpp
@@ -139,26 +139,28 @@ TEST(HeuristicDslExtractorTest, MergesCommentsAndScopeIntoDefinitions) {
   index.facts.push_back(MakeDefinition("sample::Widget", "type",
                                        "struct Widget",
                                        "Widget entity for samples", "sample"));
-  index.facts.push_back(MakeDefinition("sample::Calculator::Add", "function",
-                                       "int Add(int a, int b)",
-                                       "Adds two numbers", "sample::Calculator"));
+  index.facts.push_back(MakeDefinition(
+      "sample::Calculator::Add", "function", "int Add(int a, int b)",
+      "Adds two numbers", "sample::Calculator"));
 
   HeuristicDslExtractor extractor;
   const auto result = extractor.Extract(index, MakeConfig());
 
   ASSERT_THAT(result.terms,
               Contains(AllOf(Field(&DslTerm::name, "sample..widget"),
-                              Field(&DslTerm::definition,
-                                    AllOf(HasSubstr("Widget entity for samples"),
-                                          HasSubstr("sample"))))));
-  ASSERT_THAT(result.terms,
-              Contains(AllOf(Field(&DslTerm::name, "sample..calculator..add"),
-                              Field(&DslTerm::definition,
-                                    AllOf(HasSubstr("Adds two numbers"),
-                                          HasSubstr("sample::Calculator"))),
-                              Field(&DslTerm::evidence,
-                                    Contains(HasSubstr(
-                                        "sample::Calculator@sample::Calculator::Add::location"))))));
+                             Field(&DslTerm::definition,
+                                   AllOf(HasSubstr("Widget entity for samples"),
+                                         HasSubstr("sample"))))));
+  ASSERT_THAT(
+      result.terms,
+      Contains(AllOf(
+          Field(&DslTerm::name, "sample..calculator..add"),
+          Field(&DslTerm::definition, AllOf(HasSubstr("Adds two numbers"),
+                                            HasSubstr("sample::Calculator"))),
+          Field(
+              &DslTerm::evidence,
+              Contains(HasSubstr(
+                  "sample::Calculator@sample::Calculator::Add::location"))))));
 }
 
 } // namespace

--- a/tests/test_support/fixtures/end_to_end_expected_dsl.md
+++ b/tests/test_support/fixtures/end_to_end_expected_dsl.md
@@ -14,7 +14,7 @@
 | --- | --- | --- | --- | --- | --- |
 | use | Action | int Use(const Widget &) | uses Widget | calls Add | int Add(int, int) | <root>/src/main.cpp:7:1-7:74<br><root>/src/main.cpp:7:15-7:21<br><root>/src/main.cpp:7:40-7:71 | Use | 3 |
 | add | Action | int Add(int, int) | <root>/src/main.cpp:5:1-5:40<br><root>/src/main.cpp:7:40-7:71 | Add | 2 |
-| widget | Entity | Widget | value | value: int | <root>/src/main.cpp:1:1-3:2<br><root>/src/main.cpp:2:3-2:12<br><root>/src/main.cpp:7:15-7:21 | Widget | 3 |
+| widget | Entity | Widget | value | value: int | <root>/src/main.cpp:1:1-3:2<br>Widget<br>&nbsp;&nbsp;Range: <root>/src/main.cpp:2:3-2:12<br><root>/src/main.cpp:7:15-7:21 | Widget | 3 |
 
 ## External Dependencies
 


### PR DESCRIPTION
## Summary
- extend AST facts with doc comments and scope paths captured during clang traversal
- propagate scope and comment details into heuristic extraction definitions and evidence
- update AST indexer and extractor tests to cover nested scopes and comment-derived intent

## Testing
- cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug *(fails: libclang not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a8b4bfdc832ab8530ba374295674)