### PR TITLE
Add relevance filtering to heuristic DSL extractor

### DIFF
--- a/src/heuristic_dsl_extractor.cpp
+++ b/src/heuristic_dsl_extractor.cpp
@@ -44,8 +44,7 @@ using RelationshipMap =
 using TermMap = std::unordered_map<std::string, dsl::DslTerm>;
 using AliasMap =
     std::unordered_map<std::string, std::unordered_set<std::string>>;
-using FallbackDefinitionMap =
-    std::unordered_map<std::string, std::string>;
+using FallbackDefinitionMap = std::unordered_map<std::string, std::string>;
 
 std::string CanonicalizeName(std::string name) {
   std::replace(name.begin(), name.end(), ':', '.');
@@ -398,8 +397,8 @@ enum class TermRelevance { kDrop, kLowPriority, kKeep };
 
 TermRelevance EvaluateRelevance(const dsl::DslTerm &term,
                                 const FallbackDefinitionMap &fallbacks) {
-  const bool helper_like =
-      ContainsHelperKeyword(term.name) || ContainsHelperKeyword(term.definition);
+  const bool helper_like = ContainsHelperKeyword(term.name) ||
+                           ContainsHelperKeyword(term.definition);
   const bool meaningful_definition = HasMeaningfulDefinition(term);
   int score = term.usage_count;
   if (meaningful_definition) {
@@ -408,8 +407,7 @@ TermRelevance EvaluateRelevance(const dsl::DslTerm &term,
   if (helper_like) {
     score -= 2;
   }
-  if (!meaningful_definition &&
-      fallbacks.find(term.name) != fallbacks.end()) {
+  if (!meaningful_definition && fallbacks.find(term.name) != fallbacks.end()) {
     --score;
   }
   if (score <= 0) {

--- a/tests/heuristic_dsl_extractor_test.cpp
+++ b/tests/heuristic_dsl_extractor_test.cpp
@@ -1,6 +1,8 @@
 #include <dsl/heuristic_dsl_extractor.h>
 #include <dsl/models.h>
 
+#include <algorithm>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -161,6 +163,69 @@ TEST(HeuristicDslExtractorTest, MergesCommentsAndScopeIntoDefinitions) {
               &DslTerm::evidence,
               Contains(HasSubstr(
                   "sample::Calculator@sample::Calculator::Add::location"))))));
+}
+
+TEST(HeuristicDslExtractorTest, MarksHelpersAsLowRelevance) {
+  AstIndex index;
+  index.facts.push_back(MakeDefinition("app::RunPipeline", "function",
+                                       "void RunPipeline()",
+                                       "Runs the pipeline", "app"));
+  index.facts.push_back(
+      MakeDefinition("helpers::LoggingHelper", "function",
+                     "void LoggingHelper()", "Utility helper for logging",
+                     "helpers"));
+  index.facts.push_back(MakeRelationshipFact(
+      "app::RunPipeline", "call", "helpers::LoggingHelper",
+      AstFact::TargetScope::kInProject, "void helpers::LoggingHelper()",
+      "calls helper", "app"));
+
+  HeuristicDslExtractor extractor;
+  const auto result = extractor.Extract(index, MakeConfig());
+
+  const auto pipeline_term = std::find_if(
+      result.terms.begin(), result.terms.end(), [](const auto &term) {
+        return term.name == "app..runpipeline";
+      });
+  ASSERT_NE(pipeline_term, result.terms.end());
+  EXPECT_THAT(pipeline_term->definition, HasSubstr("Runs the pipeline"));
+
+  const auto helper_term = std::find_if(
+      result.terms.begin(), result.terms.end(), [](const auto &term) {
+        return term.name == "helpers..logginghelper";
+      });
+  ASSERT_NE(helper_term, result.terms.end());
+  EXPECT_THAT(helper_term->definition,
+              HasSubstr("Low relevance: helper/utility"));
+  EXPECT_GE(helper_term->usage_count, 2);
+}
+
+TEST(HeuristicDslExtractorTest, DropsPlaceholderOnlyEntries) {
+  AstIndex index;
+  auto ignored = MakeDefinition("std::IgnoredType", "type", "");
+  ignored.descriptor.clear();
+  index.facts.push_back(ignored);
+
+  auto placeholder =
+      MakeDefinition("helpers::TempUtility", "function", "", "", "helpers");
+  placeholder.descriptor.clear();
+  index.facts.push_back(placeholder);
+
+  index.facts.push_back(MakeDefinition("core::RealWork", "function",
+                                       "void RealWork()", "Performs work"));
+
+  HeuristicDslExtractor extractor;
+  const auto result = extractor.Extract(index, MakeConfig());
+
+  EXPECT_THAT(result.terms,
+              Not(Contains(Field(&DslTerm::name, "helpers..temputility"))));
+  EXPECT_THAT(result.terms,
+              Not(Contains(Field(&DslTerm::name, "std..ignoredtype"))));
+  ASSERT_THAT(result.terms, Contains(Field(&DslTerm::name, "core..realwork")));
+  for (const auto &term : result.terms) {
+    EXPECT_THAT(term.definition,
+                AllOf(Not(HasSubstr("Inferred from symbol context")),
+                      Not(HasSubstr("Declared as"))));
+  }
 }
 
 } // namespace

--- a/tests/heuristic_dsl_extractor_test.cpp
+++ b/tests/heuristic_dsl_extractor_test.cpp
@@ -170,10 +170,9 @@ TEST(HeuristicDslExtractorTest, MarksHelpersAsLowRelevance) {
   index.facts.push_back(MakeDefinition("app::RunPipeline", "function",
                                        "void RunPipeline()",
                                        "Runs the pipeline", "app"));
-  index.facts.push_back(
-      MakeDefinition("helpers::LoggingHelper", "function",
-                     "void LoggingHelper()", "Utility helper for logging",
-                     "helpers"));
+  index.facts.push_back(MakeDefinition(
+      "helpers::LoggingHelper", "function", "void LoggingHelper()",
+      "Utility helper for logging", "helpers"));
   index.facts.push_back(MakeRelationshipFact(
       "app::RunPipeline", "call", "helpers::LoggingHelper",
       AstFact::TargetScope::kInProject, "void helpers::LoggingHelper()",
@@ -183,16 +182,14 @@ TEST(HeuristicDslExtractorTest, MarksHelpersAsLowRelevance) {
   const auto result = extractor.Extract(index, MakeConfig());
 
   const auto pipeline_term = std::find_if(
-      result.terms.begin(), result.terms.end(), [](const auto &term) {
-        return term.name == "app..runpipeline";
-      });
+      result.terms.begin(), result.terms.end(),
+      [](const auto &term) { return term.name == "app..runpipeline"; });
   ASSERT_NE(pipeline_term, result.terms.end());
   EXPECT_THAT(pipeline_term->definition, HasSubstr("Runs the pipeline"));
 
   const auto helper_term = std::find_if(
-      result.terms.begin(), result.terms.end(), [](const auto &term) {
-        return term.name == "helpers..logginghelper";
-      });
+      result.terms.begin(), result.terms.end(),
+      [](const auto &term) { return term.name == "helpers..logginghelper"; });
   ASSERT_NE(helper_term, result.terms.end());
   EXPECT_THAT(helper_term->definition,
               HasSubstr("Low relevance: helper/utility"));


### PR DESCRIPTION
## Summary
- add relevance scoring and fallback handling to the heuristic extractor to filter noisy helper symbols and mark low-relevance terms
- update external dependency handling and glossary evidence to avoid placeholder definitions for excluded entries
- extend extractor tests to cover helper/utilities and placeholder AST facts under ignored namespaces

## Testing
- cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug *(fails: libclang not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949d9d140f8832a9d00ea055f361f6b)